### PR TITLE
Fix AttributeErrors and NameErrors in resnet, CIFAR10Dataset, and Scheduler

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -44,13 +44,13 @@ algo_map = {
     "fedavg": [FedAvgServer, FedAvgClient],
     "isolated": [IsolatedServer],
 
-    "fedran": [FedRanServer, FedRanClient],
-    "fedgrid": [FedGridServer, FedGridClient],
-    "fedtorus": [FedTorusServer, FedTorusClient],
+#    "fedran": [FedRanServer, FedRanClient],
+#    "fedgrid": [FedGridServer, FedGridClient],
+#    "fedtorus": [FedTorusServer, FedTorusClient],
     "fedass": [FedAssServer, FedAssClient],
     "fediso": [FedIsoServer, FedIsoClient],
     "fedweight": [FedWeightServer, FedWeightClient],
-    "fedring": [FedRingServer, FedRingClient],
+#    "fedring": [FedRingServer, FedRingClient],
     "fedstatic": [FedStaticServer, FedStaticClient],
 
     "swarm": [SWARMServer, SWARMClient],

--- a/src/utils/data_utils.py
+++ b/src/utils/data_utils.py
@@ -16,7 +16,7 @@ class CIFAR10Dataset:
     """
     def __init__(self, dpath: str, rot_angle: int = 0) -> None:
         self.image_size = 32
-        self.num_cls = 10
+        self.NUM_CLS = 10
         self.mean = np.array((0.4914, 0.4822, 0.4465))
         self.std = np.array((0.2023, 0.1994, 0.2010))
         self.num_channels = 3

--- a/src/utils/model_utils.py
+++ b/src/utils/model_utils.py
@@ -44,16 +44,16 @@ class ModelUtils():
         if model_name == "resnet10":
             if pretrained:
                 raise ValueError("Pretrained model not available for resnet10")
-            model = resnet.ResNet10(**kwargs)
+            model = resnet.resnet10(**kwargs)
         elif model_name == "resnet18":
             model = resnet_in.resnet18(
-                pretrained=True, **kwargs) if pretrained else resnet.ResNet18(**kwargs)
+                pretrained=True, **kwargs) if pretrained else resnet.resnet18(**kwargs)
         elif model_name == "resnet34":
             model = resnet_in.resnet34(
-                pretrained=True, **kwargs) if pretrained else resnet.ResNet34(**kwargs)
+                pretrained=True, **kwargs) if pretrained else resnet.resnet34(**kwargs)
         elif model_name == "resnet50":
             model = resnet_in.resnet50(
-                pretrained=True, **kwargs) if pretrained else resnet.ResNet50(**kwargs)
+                pretrained=True, **kwargs) if pretrained else resnet.resnet50(**kwargs)
         else:
             raise ValueError(f"Model name {model_name} not supported")
         model = model.to(device)


### PR DESCRIPTION
Encountering errors in resnet module and CIFAR10Dataset when trying to run the 
`mpirun --allow-run-as-root -np 4 -host localhost:4 python main.py` with the default config setting.
Below are the details of each error:


1. **AttributeError: module 'resnet' has no attribute 'ResNet34'. Did you mean: 'resnet34'?**
   - **Cause:** The `resnet` module does not have an attribute named `ResNet34`.
   - **Fix:** Replaced `ResNet34` with `resnet34` in file model_utils to match the correct attribute name in the `resnet` module.
   -  Replaced `ResNet10` with `resnet10`,  Replaced `ResNet18` with `resnet18`, Replaced `ResNet50` with `resnet50`, in file model_utils to match the correct attribute name in the `resnet` module.
   

2. **AttributeError: 'CIFAR10Dataset' object has no attribute 'NUM_CLS'**
   - **Cause:** The `CIFAR10Dataset` object was missing the `NUM_CLS` attribute.
   - **Fix:** Replaced the `num_cls` with `NUM_CLS` attribute to the `CIFAR10Dataset` class definition.

3. **NameError: name 'FedRanServer' is not defined. Did you mean: 'FedValServer'?**
   - **Cause:** The `FedRanServer` class was not imported.
   - **Fix:** Commented out the `FedRanServer` reference to prevent the error.
   
4. **NameErrors for other server and client classes:**
   - **Cause:** Classes such as `FedRanClient`, `FedGridServer`, `FedGridClient`, `FedTorusServer`, `FedTorusClient`, `FedRingServer`, and `FedRingClient` were not imported.
   - **Fix:** Commented out references to these classes to prevent the errors.
  
 ### Summary of Changes

- **File:** `src/utils/model_utils.py`
  - Changed `ResNet34` to `resnet34`, `ResNet10` with `resnet10`, `ResNet18` with `resnet18`, `ResNet50` with `resnet50`

- **File:** `src/utils/data_utils.py`
  - Changed `num_cls` with `NUM_CLS` attribute to `CIFAR10Dataset` class.

- **File:** `src/scheduler.py`
  - Commented out the `FedRanServer`, `FedRanClient`, `FedGridServer`, `FedGridClient`, `FedTorusServer`, `FedTorusClient`, `FedRingServer`, `FedRingClient` reference to prevent the NameError.

### Testing

- **Steps Taken:**
  1. Ran `mpirun --allow-run-as-root -np 4 -host localhost:4 python main.py` with the updated code.
  2. Verified that the script runs without encountering the previously mentioned errors.

- **Results:** The script executed successfully with the default config settings, confirming that the issues were resolved.

### Additional Notes

- **Dependencies:** No new dependencies were added.

Please review the changes and let me know if there are any further modifications needed.