### PR TITLE
Malicious Attacks

### DIFF
--- a/src/algos/attack_add_noise.py
+++ b/src/algos/attack_add_noise.py
@@ -1,0 +1,41 @@
+from collections import OrderedDict
+from torch import Tensor
+from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+import random
+
+ConfigType: TypeAlias = Dict[
+    str,
+    Union[
+        str,
+        float,
+        int,
+        bool,
+        List[str],
+        List[int],
+        List[float],
+        List[bool],
+        Tuple[Union[int, str, float, bool, None], ...],
+        Optional[List[int]],
+    ],
+]
+
+class AddNoiseAttack:
+    '''
+    Add a Gaussian noise to the model weights
+    '''
+    def __init__(self, config: ConfigType, state_dict: OrderedDict[str, Tensor]) -> None:
+        self.state_dict = state_dict
+        self.noise_rate = float(config.get("noise_rate", 1))
+        self.noise_mean = float(config.get("noise_mean", 0))
+        self.noise_std = float(config.get("noise_std", 1))
+        # TODO: this is also often known as backdoor attack,
+        # where the noise is added without noticeable differences in model performance
+        # we should find ways to study this
+        
+    def get_representation(self) -> OrderedDict[str, Tensor]:
+        return OrderedDict(
+            {key: val + self.noise_std * random.gauss(self.noise_mean, self.noise_std)
+             if random.random() < self.noise_rate
+             else val
+             for key, val in self.state_dict.items()}
+        )

--- a/src/algos/attack_add_noise.py
+++ b/src/algos/attack_add_noise.py
@@ -1,23 +1,7 @@
 from collections import OrderedDict
 from torch import Tensor
-from typing import TypeAlias, Dict, List, Union, Tuple, Optional
 import random
-
-ConfigType: TypeAlias = Dict[
-    str,
-    Union[
-        str,
-        float,
-        int,
-        bool,
-        List[str],
-        List[int],
-        List[float],
-        List[bool],
-        Tuple[Union[int, str, float, bool, None], ...],
-        Optional[List[int]],
-    ],
-]
+from utils.types import ConfigType
 
 class AddNoiseAttack:
     '''

--- a/src/algos/attack_bad_weights.py
+++ b/src/algos/attack_bad_weights.py
@@ -1,0 +1,35 @@
+from collections import OrderedDict
+from torch import Tensor
+from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+import random
+
+ConfigType: TypeAlias = Dict[
+    str,
+    Union[
+        str,
+        float,
+        int,
+        bool,
+        List[str],
+        List[int],
+        List[float],
+        List[bool],
+        Tuple[Union[int, str, float, bool, None], ...],
+        Optional[List[int]],
+    ],
+]
+
+class BadWeightsAttack:
+    def __init__(self, config: ConfigType, state_dict: OrderedDict[str, Tensor]) -> None:
+        self.state_dict = state_dict
+        self.weight = config.get("weight", 0)
+        self.corrupt_portion = float(config.get("corrupt_portion", 1))
+        # TODO: add start and end epochs, or other conditions such as what rounds
+
+    def get_representation(self) -> OrderedDict[str, Tensor]:
+        return OrderedDict(
+            {key: val * self.weight
+             if random.random() < self.corrupt_portion
+             else val
+             for key, val in self.state_dict.items()}
+        )

--- a/src/algos/attack_bad_weights.py
+++ b/src/algos/attack_bad_weights.py
@@ -1,23 +1,7 @@
 from collections import OrderedDict
 from torch import Tensor
-from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+from utils.types import ConfigType
 import random
-
-ConfigType: TypeAlias = Dict[
-    str,
-    Union[
-        str,
-        float,
-        int,
-        bool,
-        List[str],
-        List[int],
-        List[float],
-        List[bool],
-        Tuple[Union[int, str, float, bool, None], ...],
-        Optional[List[int]],
-    ],
-]
 
 class BadWeightsAttack:
     def __init__(self, config: ConfigType, state_dict: OrderedDict[str, Tensor]) -> None:

--- a/src/algos/attack_sign_flip.py
+++ b/src/algos/attack_sign_flip.py
@@ -1,23 +1,7 @@
 from collections import OrderedDict
 from torch import Tensor
-from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+from utils.types import ConfigType
 import random
-
-ConfigType: TypeAlias = Dict[
-    str,
-    Union[
-        str,
-        float,
-        int,
-        bool,
-        List[str],
-        List[int],
-        List[float],
-        List[bool],
-        Tuple[Union[int, str, float, bool, None], ...],
-        Optional[List[int]],
-    ],
-]
 
 class SignFlipAttack:
     def __init__(self, config: ConfigType, state_dict: OrderedDict[str, Tensor]) -> None:

--- a/src/algos/attack_sign_flip.py
+++ b/src/algos/attack_sign_flip.py
@@ -1,0 +1,34 @@
+from collections import OrderedDict
+from torch import Tensor
+from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+import random
+
+ConfigType: TypeAlias = Dict[
+    str,
+    Union[
+        str,
+        float,
+        int,
+        bool,
+        List[str],
+        List[int],
+        List[float],
+        List[bool],
+        Tuple[Union[int, str, float, bool, None], ...],
+        Optional[List[int]],
+    ],
+]
+
+class SignFlipAttack:
+    def __init__(self, config: ConfigType, state_dict: OrderedDict[str, Tensor]) -> None:
+        self.state_dict = state_dict
+        self.flip_rate = float(config.get("flip_rate", 1))
+        # TODO: add start and end epochs, or other conditions such as 
+        # target label and source labels
+    def get_representation(self) -> OrderedDict[str, Tensor]:
+        return OrderedDict(
+            {key: -1 * val
+             if random.random() < self.flip_rate
+             else val
+             for key, val in self.state_dict.items()}
+        )

--- a/src/configs/algo_config.py
+++ b/src/configs/algo_config.py
@@ -1,23 +1,7 @@
-from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+from typing import Dict, List
 from .malicious_config import malicious_config_list
 import random
-
-# Correcting the type for configuration to handle all possible types
-ConfigType: TypeAlias = Dict[
-    str,
-    Union[
-        str,
-        float,
-        int,
-        bool,
-        List[str],
-        List[int],
-        List[float],
-        List[bool],
-        Tuple[Union[int, str, float, bool, None], ...],
-        Optional[List[int]],
-    ],
-]
+from utils.types import ConfigType
 
 
 def assign_colab(clients):

--- a/src/configs/algo_config.py
+++ b/src/configs/algo_config.py
@@ -71,9 +71,14 @@ traditional_fl: ConfigType = {
     "malicious_type": "normal",
 }
 
-malicious_traditional_fl: ConfigType = {
+malicious_traditional_bad_weights: ConfigType = {
     **traditional_fl,
     "malicious_type": "bad_weights",
+}
+
+malicious_traditional_flip_signs: ConfigType = {
+    **traditional_fl,
+    "malicious_type": "sign_flip",
 }
 
 
@@ -355,7 +360,8 @@ feddatarepr: ConfigType = {
 algo_config_list: List[ConfigType] = [
     iid_dispfl_clients_new,
     traditional_fl,
-    malicious_traditional_fl,
+    malicious_traditional_bad_weights,
+    malicious_traditional_flip_signs,
     fedweight,
     defkt,
     fedavg_object_detect,
@@ -373,7 +379,8 @@ algo_config_list: List[ConfigType] = [
 # Malicious List of algorithm configurations
 malicious_algo_config_list: List[ConfigType] = [
     traditional_fl,
-    malicious_traditional_fl,
+    malicious_traditional_bad_weights,
+    malicious_traditional_flip_signs,
 ]
 
 default_config_list: List[ConfigType] = [traditional_fl]

--- a/src/configs/malicious_config.py
+++ b/src/configs/malicious_config.py
@@ -1,21 +1,5 @@
 # Malicious Configuration
-from typing import TypeAlias, Dict, List, Union, Tuple, Optional
-
-ConfigType: TypeAlias = Dict[
-    str,
-    Union[
-        str,
-        float,
-        int,
-        bool,
-        List[str],
-        List[int],
-        List[float],
-        List[bool],
-        Tuple[Union[int, str, float, bool, None], ...],
-        Optional[List[int]],
-    ],
-]
+from utils.types import ConfigType
 
 label_flipping: ConfigType = {
     "flip_rate": 0.3,  # 30% of the labels are flipped

--- a/src/configs/sys_config.py
+++ b/src/configs/sys_config.py
@@ -1,7 +1,8 @@
 # System Configuration
 # TODO: Set up multiple non-iid configurations here. The goal of a separate system config
 # is to simulate different real-world scenarios without changing the algorithm configuration.
-from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+from typing import Dict, List, Optional
+from utils.types import ConfigType
 
 # from utils.config_utils import get_sliding_window_support, get_device_ids
 from .algo_config import (
@@ -10,22 +11,6 @@ from .algo_config import (
     default_config_list,
 )
 import random
-
-ConfigType: TypeAlias = Dict[
-    str,
-    Union[
-        str,
-        float,
-        int,
-        bool,
-        List[str],
-        List[int],
-        List[float],
-        List[bool],
-        Tuple[Union[int, str, float, bool, None], ...],
-        Optional[List[int]],
-    ],
-]
 
 sliding_window_8c_4cpc_support = {
     "1": [0, 1, 2, 3],

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -1,0 +1,17 @@
+from typing import TypeAlias, Dict, List, Union, Tuple, Optional
+
+ConfigType: TypeAlias = Dict[
+    str,
+    Union[
+        str,
+        float,
+        int,
+        bool,
+        List[str],
+        List[int],
+        List[float],
+        List[bool],
+        Tuple[Union[int, str, float, bool, None], ...],
+        Optional[List[int]],
+    ],
+]


### PR DESCRIPTION
This PR adds support for malicious attacks that involve sending corrupted weight representations. This includes:
* Bad Weights / Free Riding attack: sending the same weights
* Sign Flip Attack: flipping the sign of the weights
* Add Noise Attack: adding gaussian noise to the weights

This also adds support for flexible configuration of malicious node algo assignment, including sequential assignment, random assignment, by distribution, or by mapping. 