### PR TITLE
update requirements.txt

### DIFF
--- a/docs/development/common_errors.md
+++ b/docs/development/common_errors.md
@@ -2,6 +2,7 @@
 
 ### ImportError: MagickWand shared library not found.
 
+This issue comes up for mac users in particular:
 Solution:
 ```
 brew install imagemagick@6

--- a/docs/development/common_errors.md
+++ b/docs/development/common_errors.md
@@ -1,0 +1,9 @@
+# Common Errors during installation
+
+### ImportError: MagickWand shared library not found.
+
+Solution:
+```
+brew install imagemagick@6
+export MAGICK_HOME=/opt/homebrew/opt/imagemagick@6
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,6 +91,7 @@ numpy
 # nvidia-nvjitlink-cu12==12.5.40
 # nvidia-nvtx-cu12==12.1.105
 ogb==1.3.6
+opencv-python==4.10.0.84
 outdated==0.2.2
 overrides==7.7.0
 packaging==24.0
@@ -151,6 +152,7 @@ typing_extensions==4.12.0
 tzdata==2024.1
 uri-template==1.3.0
 urllib3==2.2.1
+Wand==0.6.13
 watchdog==4.0.2
 wcwidth==0.2.13
 webcolors==1.13


### PR DESCRIPTION
Fixes #100 .
Was facing these issues when pulled from the main, hence updated.

Just a small note: for mac users the following issue will pop up:
```
ImportError: MagickWand shared library not found.
```

Solution: 
```
brew install imagemagick@6
export MAGICK_HOME=/opt/homebrew/opt/imagemagick@6
```