### PR TITLE
Automate Experiments in main_exp.py

### DIFF
--- a/src/main_exp.py
+++ b/src/main_exp.py
@@ -1,0 +1,55 @@
+"""
+Given a set of experiment keys to run,
+this module writes the config files for each experiment key
+and runs the main.py script for each experiment
+"""
+
+import argparse
+import subprocess
+from typing import List
+
+from configs.sys_config import grpc_system_config
+
+# parse the arguments
+parser = argparse.ArgumentParser(description="host address of the nodes")
+parser.add_argument(
+    "-host",
+    nargs="?",
+    type=str,
+    help=f"host address of the nodes",
+)
+
+args = parser.parse_args()
+
+# for each experiment key
+# write the new config file
+exp_ids = ["test_automation_1", "test_automation_2", "test_automation_3"]
+
+for e, exp_id in enumerate(exp_ids):
+    current_config = grpc_system_config
+    current_config["exp_id"] = exp_id
+
+    # write the config file as python file configs/temp_config.py
+    with open("./configs/temp_config.py", "w") as f:
+        f.write("current_config = ")
+        f.write(str(current_config))
+
+    n: int = current_config["num_users"]
+
+    # start the supernode
+    supernode_command: List[str] = ["python", "main.py", "-host", args.host, "-super", "true", "-s", "./configs/temp_config.py"]
+    process = subprocess.Popen(supernode_command)
+
+    # start the nodes
+    command_list: List[str] = ["python", "main.py", "-host", args.host, "-s", "./configs/temp_config.py"]
+    for i in range(n):
+        print(f"Starting process for user {i} exp {exp_id}")
+        # start a Popen process
+        subprocess.Popen(command_list)
+
+    # once the experiment is done, run the next experiment
+    # Wait for the supernode process to finish
+    process.wait()
+
+    # Continue with the next set of commands after supernode finishes
+    print(f"Supernode process {exp_id} finished. Proceeding to next set of commands.")

--- a/src/utils/log_utils.py
+++ b/src/utils/log_utils.py
@@ -15,6 +15,8 @@ from torchvision.utils import make_grid, save_image  # type: ignore
 from tensorboardX import SummaryWriter  # type: ignore
 import numpy as np
 import pandas as pd
+from utils.types import ConfigType
+import json
 
 
 def deprocess(img: torch.Tensor) -> torch.Tensor:
@@ -54,7 +56,7 @@ def check_and_create_path(path: str):
         os.makedirs(path)
 
 
-def copy_source_code(config: Dict[str, Any]) -> None:
+def copy_source_code(config: ConfigType) -> None:
     """
     Copy source code to experiment folder for reproducibility.
 
@@ -102,7 +104,7 @@ class LogUtils:
     Utility class for logging and saving experiment data.
     """
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: ConfigType) -> None:
         log_dir = config["log_path"]
         load_existing = config["load_existing"]
         log_format = (
@@ -116,10 +118,18 @@ class LogUtils:
         )
         logging.getLogger().addHandler(logging.StreamHandler())
         self.log_dir = log_dir
+        self.log_config(config)
         self.init_tb(load_existing)
         self.init_npy()
         self.init_summary()
         self.init_csv()
+
+    def log_config(self, config: ConfigType):
+        """
+        Log the configuration to a json file. 
+        """
+        with open(f"{self.log_dir}/config.json", "w") as f:
+            json.dump(config, f, indent=4)
 
     def init_summary(self):
         """


### PR DESCRIPTION
Automates running experiments. Modify the experiment settings in main_exp.py. This file writes into a temp config for each new experiment. 

Example usage: `python main_exp.py -host matlaber3.media.mit.edu`
`