### PR TITLE
fixing time elapse for plot utils

### DIFF
--- a/src/utils/plot_combined_exp.py
+++ b/src/utils/plot_combined_exp.py
@@ -12,6 +12,7 @@ def combine_and_plot(
     xlabels: List[str], 
     ylabels: List[str], 
     output_dir: str, 
+    include_logs: bool = True
 ) -> None:
     """
     Combine and plot metrics from multiple experiments with 95% confidence intervals.
@@ -28,6 +29,9 @@ def combine_and_plot(
     # Ensure the output directory exists
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
+
+    if not os.path.exists(os.path.join(output_dir, 'plots')):
+        os.makedirs(os.path.join(output_dir, 'plots'))
     
     for metric_index, metric_name in enumerate(metrics_list):
         plt.figure(figsize=(12, 8), dpi=300)
@@ -36,21 +40,21 @@ def combine_and_plot(
             # Load the aggregated metric DataFrame for the experiment
             metric_df = pd.read_csv(os.path.join(experiment_path, f"{metric_name}_avg.csv"))
             # TODO: modify this to be CI
-            std_df = pd.read_csv(os.path.join(experiment_path, f"{metric_name}_std.csv"))
-            # ci_df = pd.read_csv(os.path.join(experiment_path, f"{metric_name}_ci95.csv"))
+            # std_df = pd.read_csv(os.path.join(experiment_path, f"{metric_name}_std.csv"))
+            ci_df = pd.read_csv(os.path.join(experiment_path, f"{metric_name}_ci95.csv"))
 
             # Assuming rounds or time steps are the index
             rounds = np.arange(len(metric_df))
 
             # Plot each experiment's mean with 95% CI
             mean_metric = metric_df.values.flatten()
-            std_metric = std_df.values.flatten()
-            # ci_95 = ci_df.values.flatten()
+            # std_metric = std_df.values.flatten()
+            ci_95 = ci_df.values.flatten()
 
             # Plot the mean with confidence interval as a shaded area
             plt.plot(rounds, mean_metric, label=f'{experiment_key}', linestyle='--', linewidth=1.5)
-            # plt.fill_between(rounds, mean_metric - ci_95, mean_metric + ci_95, alpha=0.2)
-            plt.fill_between(rounds, mean_metric - std_metric, mean_metric + std_metric, alpha=0.2)
+            plt.fill_between(rounds, mean_metric - ci_95, mean_metric + ci_95, alpha=0.2)
+            # plt.fill_between(rounds, mean_metric - std_metric, mean_metric + std_metric, alpha=0.2)
 
         # Plot customization
         plt.xlabel(xlabels[metric_index], fontsize=14)

--- a/src/utils/plot_combined_exp.py
+++ b/src/utils/plot_combined_exp.py
@@ -64,23 +64,33 @@ def combine_and_plot(
         plt.grid(True, linestyle='--', alpha=0.5)
 
         # Save the combined plot
-        plt.savefig(os.path.join(output_dir, f"{exp_name}_{metric_name}_combined_plot.png"), bbox_inches='tight')
+        plt.savefig(os.path.join(output_dir, 'plots', f"{exp_name}_{metric_name}_combined_plot.png"), bbox_inches='tight')
         plt.close()
 
-        print(f"Combined plot for {exp_name} {metric_name} saved to {output_dir}")
+        print(f"Combined plot for {exp_name} {metric_name} saved to {output_dir}/plots/")
 
-        # Optionally, save the combined data for further analysis
-        # combined_mean_df = pd.DataFrame({exp: pd.read_csv(os.path.join(path, f"{metric_name}_avg.csv")).values.flatten()
-        #                                  for exp, path in experiment_map.items()})
-        # combined_mean_df.to_csv(os.path.join(output_dir, f"{metric_name}_combined_avg.csv"), index=False)
+        if include_logs:
+            if not os.path.exists(os.path.join(output_dir, 'logs')):
+                os.makedirs(os.path.join(output_dir, 'logs'))
 
-        # combined_std_df = pd.DataFrame({exp: pd.read_csv(os.path.join(path, f"{metric_name}_std.csv")).values.flatten()
-        #                                  for exp, path in experiment_map.items()})
-        # combined_std_df.to_csv(os.path.join(output_dir, f"{metric_name}_combined_std.csv"), index=False)
+            # Optionally, save the combined data for further analysis
+            # catch error if something goes wrong
+            try:
+                combined_mean_df = pd.DataFrame({exp: pd.read_csv(os.path.join(path, f"{metric_name}_avg.csv")).values.flatten()
+                                                for exp, path in experiment_map.items()})
+                combined_mean_df.to_csv(os.path.join(output_dir, 'logs', f"{exp_name}_{metric_name}_combined_avg.csv"), index=False)
 
-        # combined_ci_df = pd.DataFrame({exp: pd.read_csv(os.path.join(path, f"{metric_name}_ci95.csv")).values.flatten()
-        #                                for exp, path in experiment_map.items()})
-        # combined_ci_df.to_csv(os.path.join(output_dir, f"{metric_name}_combined_ci95.csv"), index=False)
+                combined_std_df = pd.DataFrame({exp: pd.read_csv(os.path.join(path, f"{metric_name}_std.csv")).values.flatten()
+                                                for exp, path in experiment_map.items()})
+                combined_std_df.to_csv(os.path.join(output_dir, 'logs', f"{exp_name}_{metric_name}_combined_std.csv"), index=False)
+
+                combined_ci_df = pd.DataFrame({exp: pd.read_csv(os.path.join(path, f"{metric_name}_ci95.csv")).values.flatten()
+                                            for exp, path in experiment_map.items()})
+                combined_ci_df.to_csv(os.path.join(output_dir,  'logs', f"{exp_name}_{metric_name}_combined_ci95.csv"), index=False)
+
+                print(f"Combined logs for {exp_name} {metric_name} saved to {output_dir}/logs/")
+            except Exception as e:
+                print(f"Error saving logs: {e} for {exp_name} {metric_name}")
 
 # Example usage for malicious attacks
 if __name__ == "__main__":

--- a/src/utils/post_hoc_plot_utils.py
+++ b/src/utils/post_hoc_plot_utils.py
@@ -426,11 +426,17 @@ def plot_all_metrics(logs_dir: str, per_round: bool = True, per_time: bool = Tru
                 rounds=all_users_data['rounds'], 
                 metric_name=key, 
                 ylabel=display_name, 
-                output_dir=f'{logs_dir}plots/',
+                output_dir=f'{logs_dir}/plots/',
                 plot_avg_only=plot_avg_only,
                 **kwargs
                 )
+
     if per_time:
+        time_data = os.path.join(logs_dir, 'node_1/csv/time_elapsed.csv')
+        # check if time elapsed data exists
+        if not os.path.exists(time_data):
+            print("Time elapsed data not found. Skipping per-time plotting.")
+            return
         all_users_data = aggregate_per_realtime_data(logs_dir, **kwargs)
 
         for key, display_name in metrics_map.items():
@@ -439,7 +445,7 @@ def plot_all_metrics(logs_dir: str, per_round: bool = True, per_time: bool = Tru
                 time_ticks=all_users_data[key].index.values, 
                 metric_name=key, 
                 ylabel=display_name, 
-                output_dir=f'{logs_dir}plots/',
+                output_dir=f'{logs_dir}/plots/',
                 plot_avg_only=plot_avg_only,
                 **kwargs
                 )
@@ -468,7 +474,7 @@ if __name__ == "__main__":
             try:
                 print(f"Processing logs in: {logs_dir}")
                 avg_metrics, std_metrics, df_metrics = aggregate_metrics_across_users(logs_dir)
-                plot_all_metrics(logs_dir)
+                plot_all_metrics(logs_dir, per_round=True, per_time=True, plot_avg_only=True)
             except Exception as e:
                 print(f"Error processing {logs_dir}: {e}")
                 continue


### PR DESCRIPTION
Instead of throwing an error, combining plot utils will now skip the realtime section if `time_elapsed.csv` doesn't exist. In addition, this PR separates the `plots` and `logs` folders when combining plots. 

We also plot CI-95 as the default

New params: 
`include_logs: bool = True`