### PR TITLE
Efficient automated GitHub testing

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -2,12 +2,12 @@ name: Test Training Code with gRPC
 
 on:
   # used for debugging purposes
-  workflow_dispatch:
+  # workflow_dispatch:
   push:
     branches:
       # run test on push to main only
-      # - main
-      - "*"
+      - main
+      # - "*"
   pull_request:
     branches:
       - main

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -6,8 +6,8 @@ on:
   push:
     branches:
       # run test on push to main only
-      - main
-      # - "*"
+      # - main
+      - "*"
   pull_request:
     branches:
       - main

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -39,7 +39,7 @@ jobs:
           sudo apt install -y libopenmpi-dev openmpi-bin
           sudo apt-get install -y libgl1 libglib2.0-0
 
-          pip install -r requirements.txt
+          pip install -r requirements_cpu.txt
 
       # Step 4: Run gRPC server and client
       - name: Run test

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -39,18 +39,16 @@ jobs:
           sudo apt install -y libopenmpi-dev openmpi-bin
           sudo apt-get install -y libgl1 libglib2.0-0
 
-          pip install -r requirements_cpu.txt
+          pip install -r requirements.txt
 
       # Step 4: Run gRPC server and client
       - name: Run test
         run: |
           cd src
-          # chmod +x ./configs/algo_config_test.py
-
           echo "starting main grpc"
-          python main_grpc.py -n 4 -host localhost 
+          python main_grpc.py -n 4 -host localhost -dev True
           echo "starting main"
-          python main.py -super true -s "./configs/sys_config_test.py"
+          python main.py -b "./configs/algo_config_test.py" -s "./configs/sys_config_test.py" -super true
           echo "done"
 
       # further checks:

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -2,7 +2,7 @@ name: Test Training Code with gRPC
 
 on:
   # used for debugging purposes
-  # workflow_dispatch:
+  workflow_dispatch:
   push:
     branches:
       # run test on push to main only

--- a/src/algos/base_class.py
+++ b/src/algos/base_class.py
@@ -532,6 +532,13 @@ class BaseClient(BaseNode):
             if config.get("test_samples_per_class", None) is not None:
                 test_dset, _ = balanced_subset(test_dset, config["test_samples_per_class"])
 
+            #reduce test_dset size
+            if config.get("workflow_test", False):
+                print("Workflow testing: Reducing test size...")
+                reduced_test_size = 1000
+                indices = np.random.choice(len(test_dset), reduced_test_size, replace=False)
+                test_dset = Subset(test_dset, indices)
+
             samples_per_user = config["samples_per_user"]
             batch_size: int = config["batch_size"] # type: ignore
             print(f"samples per user: {samples_per_user}, batch size: {batch_size}")
@@ -686,6 +693,7 @@ class BaseClient(BaseNode):
             if self.dset.startswith("domainnet"):
                 test_dset = CacheDataset(test_dset)
 
+            print(f"test_dset size: {len(test_dset)}")
             self._test_loader = DataLoader(test_dset, batch_size=batch_size)
             # TODO: fix print_data_summary
             # self.print_data_summary(train_dset, test_dset, val_dset=val_dset)

--- a/src/algos/base_class.py
+++ b/src/algos/base_class.py
@@ -532,13 +532,6 @@ class BaseClient(BaseNode):
             if config.get("test_samples_per_class", None) is not None:
                 test_dset, _ = balanced_subset(test_dset, config["test_samples_per_class"])
 
-            #reduce test_dset size
-            if config.get("workflow_test", False):
-                print("Workflow testing: Reducing test size...")
-                reduced_test_size = 1000
-                indices = np.random.choice(len(test_dset), reduced_test_size, replace=False)
-                test_dset = Subset(test_dset, indices)
-
             samples_per_user = config["samples_per_user"]
             batch_size: int = config["batch_size"] # type: ignore
             print(f"samples per user: {samples_per_user}, batch size: {batch_size}")
@@ -693,7 +686,14 @@ class BaseClient(BaseNode):
             if self.dset.startswith("domainnet"):
                 test_dset = CacheDataset(test_dset)
 
+            # reduce test_dset size
+            if config.get("test_samples_per_user", 0) != 0:
+                print(f"Reducing test size to {config.get('test_samples_per_user', 0)}")
+                reduced_test_size = config.get("test_samples_per_user", 0)
+                indices = np.random.choice(len(test_dset), reduced_test_size, replace=False)
+                test_dset = Subset(test_dset, indices)
             print(f"test_dset size: {len(test_dset)}")
+
             self._test_loader = DataLoader(test_dset, batch_size=batch_size)
             # TODO: fix print_data_summary
             # self.print_data_summary(train_dset, test_dset, val_dset=val_dset)

--- a/src/configs/algo_config.py
+++ b/src/configs/algo_config.py
@@ -37,6 +37,7 @@ traditional_fl: ConfigType = {
     "model": "resnet10",
     "model_lr": 3e-4,
     "batch_size": 256,
+    "workflow_test": False,
 }
 
 test_fl_inversion: ConfigType = {

--- a/src/configs/algo_config.py
+++ b/src/configs/algo_config.py
@@ -204,7 +204,7 @@ fedstatic: ConfigType = {
     # Collaboration setup
     "algo": "fedstatic",
     "topology": {"name": "watts_strogatz", "k": 3, "p": 0.2}, # type: ignore
-    "rounds": 1,
+    "rounds": 3,
     # Model parameters
     "optimizer": "sgd", # TODO comment out for real training
     "model": "resnet10",

--- a/src/configs/algo_config.py
+++ b/src/configs/algo_config.py
@@ -37,7 +37,6 @@ traditional_fl: ConfigType = {
     "model": "resnet10",
     "model_lr": 3e-4,
     "batch_size": 256,
-    "workflow_test": False,
 }
 
 test_fl_inversion: ConfigType = {

--- a/src/configs/algo_config_test.py
+++ b/src/configs/algo_config_test.py
@@ -21,7 +21,6 @@ traditional_fl: ConfigType = {
     "model": "resnet10",
     "model_lr": 3e-4,
     "batch_size": 256,
-    "workflow_test": True,
 }
 
 # default_config_list: List[ConfigType] = [fedstatic, fedstatic, fedstatic, fedstatic]

--- a/src/configs/algo_config_test.py
+++ b/src/configs/algo_config_test.py
@@ -21,6 +21,7 @@ traditional_fl: ConfigType = {
     "model": "resnet10",
     "model_lr": 3e-4,
     "batch_size": 256,
+    "workflow_test": True,
 }
 
 # default_config_list: List[ConfigType] = [fedstatic, fedstatic, fedstatic, fedstatic]

--- a/src/configs/sys_config.py
+++ b/src/configs/sys_config.py
@@ -158,7 +158,7 @@ CIFAR10_DSET = "cifar10"
 CIAR10_DPATH = "./datasets/imgs/cifar10/"
 
 NUM_COLLABORATORS = 1
-DUMP_DIR = "/Users/kathryn/MIT/UROP/Media Lab/sonar_experiments/"
+DUMP_DIR = "/tmp/"
 
 num_users = 4
 

--- a/src/configs/sys_config.py
+++ b/src/configs/sys_config.py
@@ -366,7 +366,6 @@ grpc_system_config: ConfigType = {
         "matlaber3": [0, 1, 2, 3],
         "matlaber4": [0, 2, 3, 4, 5, 6, 7],
     },
-    "workflow_test": False,
 }
 
 grpc_system_config_gia: ConfigType = {

--- a/src/configs/sys_config.py
+++ b/src/configs/sys_config.py
@@ -365,7 +365,8 @@ grpc_system_config: ConfigType = {
         "matlaber12": [0, 1, 2, 3],
         "matlaber3": [0, 1, 2, 3],
         "matlaber4": [0, 2, 3, 4, 5, 6, 7],
-    }
+    },
+    "workflow_test": False,
 }
 
 grpc_system_config_gia: ConfigType = {

--- a/src/configs/sys_config.py
+++ b/src/configs/sys_config.py
@@ -160,8 +160,7 @@ CIAR10_DPATH = "./datasets/imgs/cifar10/"
 NUM_COLLABORATORS = 1
 DUMP_DIR = "/tmp/"
 
-num_users = 4
-
+num_users = 3
 mpi_system_config: ConfigType = {
     "exp_id": "",
     "comm": {"type": "MPI"},
@@ -175,11 +174,11 @@ mpi_system_config: ConfigType = {
     # The device_ids dictionary depicts the GPUs on which the nodes reside.
     # For a single-GPU environment, the config will look as follows (as it follows a 0-based indexing):
     #  "device_ids": {"node_0": [0], "node_1": [0], "node_2": [0], "node_3": [0]},
-    "device_ids": get_device_ids(num_users=4, gpus_available=[1, 2]),
+    "device_ids": get_device_ids(num_users=3, gpus_available=[1, 2]),
     # use this when the list needs to be imported from the algo_config
     # "algo": get_algo_configs(num_users=3, algo_configs=algo_configs_list),
     "algos": get_algo_configs(
-        num_users=4,
+        num_users=3,
         algo_configs=default_config_list
     ),  # type: ignore
     "samples_per_user": 5555,  # TODO: To model scenarios where different users have different number of samples
@@ -365,7 +364,7 @@ grpc_system_config: ConfigType = {
         "matlaber12": [0, 1, 2, 3],
         "matlaber3": [0, 1, 2, 3],
         "matlaber4": [0, 2, 3, 4, 5, 6, 7],
-    },
+    }
 }
 
 grpc_system_config_gia: ConfigType = {
@@ -388,6 +387,5 @@ grpc_system_config_gia: ConfigType = {
     "gia":True,
     "gia_attackers":[1]
 }
-  
 current_config = grpc_system_config
 # current_config = mpi_system_config

--- a/src/configs/sys_config.py
+++ b/src/configs/sys_config.py
@@ -387,5 +387,6 @@ grpc_system_config_gia: ConfigType = {
     "gia":True,
     "gia_attackers":[1]
 }
+
 current_config = grpc_system_config
 # current_config = mpi_system_config

--- a/src/configs/sys_config_test.py
+++ b/src/configs/sys_config_test.py
@@ -81,7 +81,6 @@ def get_algo_configs(
 CIFAR10_DSET = "cifar10"
 CIAR10_DPATH = "./datasets/imgs/cifar10/"
 
-# DUMP_DIR = "../../../../../../../home/"
 DUMP_DIR = "/tmp/"
 
 NUM_COLLABORATORS = 1

--- a/src/configs/sys_config_test.py
+++ b/src/configs/sys_config_test.py
@@ -120,7 +120,7 @@ grpc_system_config: ConfigType = {
     "alpha_data": 1.0,
     "exp_keys": [],
     "dropout_dicts": dropout_dicts,
-    "test_samples_per_user": 1000,
+    "test_samples_per_user": 200,
     "log_memory": True,
     # "streaming_aggregation": True, # Make it true for fedstatic
     "assign_based_on_host": True,
@@ -129,6 +129,6 @@ grpc_system_config: ConfigType = {
         "matlaber12": [0, 1, 2, 3],
         "matlaber3": [0, 1, 2, 3],
         "matlaber4": [0, 2, 3, 4, 5, 6, 7],
-    },
+    }
 }
 current_config = grpc_system_config

--- a/src/configs/sys_config_test.py
+++ b/src/configs/sys_config_test.py
@@ -120,7 +120,7 @@ grpc_system_config: ConfigType = {
     "alpha_data": 1.0,
     "exp_keys": [],
     "dropout_dicts": dropout_dicts,
-    "test_samples_per_user": 100,
+    "test_samples_per_user": 1000,
     "log_memory": True,
     # "streaming_aggregation": True, # Make it true for fedstatic
     "assign_based_on_host": True,
@@ -130,6 +130,5 @@ grpc_system_config: ConfigType = {
         "matlaber3": [0, 1, 2, 3],
         "matlaber4": [0, 2, 3, 4, 5, 6, 7],
     },
-    "workflow_test": True,
 }
 current_config = grpc_system_config

--- a/src/configs/sys_config_test.py
+++ b/src/configs/sys_config_test.py
@@ -120,7 +120,7 @@ grpc_system_config: ConfigType = {
     "alpha_data": 1.0,
     "exp_keys": [],
     "dropout_dicts": dropout_dicts,
-    "test_samples_per_user": 200,
+    "test_samples_per_user": 100,
     "log_memory": True,
     # "streaming_aggregation": True, # Make it true for fedstatic
     "assign_based_on_host": True,
@@ -129,6 +129,7 @@ grpc_system_config: ConfigType = {
         "matlaber12": [0, 1, 2, 3],
         "matlaber3": [0, 1, 2, 3],
         "matlaber4": [0, 2, 3, 4, 5, 6, 7],
-    }
+    },
+    "workflow_test": True,
 }
 current_config = grpc_system_config

--- a/src/main_grpc.py
+++ b/src/main_grpc.py
@@ -23,10 +23,19 @@ parser.add_argument(
     help=f"host address of the nodes",
 )
 
+parser.add_argument(
+    "-dev",
+    nargs="?",
+    type=bool,
+    help=f"whether or not development testing",
+)
+
 args : argparse.Namespace = parser.parse_args()
 
 # Command for opening each process
 command_list: List[str] = ["python", "main.py", "-host", args.host]
+if args.dev == True:
+    command_list: List[str] = ["python", "main.py", "-b", "./configs/algo_config_test.py", "-s", "./configs/sys_config_test.py", "-host", args.host]
 
 # Start process for each user
 for i in range(args.n):

--- a/src/utils/communication/mpi.py
+++ b/src/utils/communication/mpi.py
@@ -48,7 +48,6 @@ class MPICommUtils(CommunicationInterface):
     def send_quorum(self) -> Any:
         # return super().send_quorum(node_ids)
         pass
-      
     def register_self(self, obj: "BaseNode"):
         self.base_node = obj
     
@@ -76,7 +75,6 @@ class MPICommUtils(CommunicationInterface):
                 self.comm.recv(source=dest, tag=1)
                 self.send(dest)
         print(f"Node {self.rank} listener thread ended")
-        
     def get_model(self) -> List[OrderedDict[str, Tensor]] | None:
         print(f"getting model from {self.rank}, {self.base_node}")
         if not self.base_node:
@@ -153,7 +151,6 @@ class MPICommUtils(CommunicationInterface):
         """
         items: List[Any] = []
         for i in range(1, self.size):
-            print(f"receiving this data: {self.receive(i)}")
             items.append(self.receive(i))
         return items
     

--- a/src/utils/communication/mpi.py
+++ b/src/utils/communication/mpi.py
@@ -48,6 +48,7 @@ class MPICommUtils(CommunicationInterface):
     def send_quorum(self) -> Any:
         # return super().send_quorum(node_ids)
         pass
+    
     def register_self(self, obj: "BaseNode"):
         self.base_node = obj
     
@@ -75,6 +76,7 @@ class MPICommUtils(CommunicationInterface):
                 self.comm.recv(source=dest, tag=1)
                 self.send(dest)
         print(f"Node {self.rank} listener thread ended")
+
     def get_model(self) -> List[OrderedDict[str, Tensor]] | None:
         print(f"getting model from {self.rank}, {self.base_node}")
         if not self.base_node:


### PR DESCRIPTION
Optimized automated GitHub testing to run faster with these changes:
- Created additional value for configs called "workflow_test". Set this value to True if you want to run in testing mode
- Testing mode will reduce the test set size. Currently the test set size is reduced from 10,000 to 1,000.
- Made changes to main_grpc.py to include an extra argument to indicate that we want to spin nodes that run in testing mode. Set the argument -dev to True if testing and False if not.

Result: Test Training Code with gRPC GitHub Action runs in 4 mins compared to 13 mins previously.